### PR TITLE
Changed the type of temprature_sens_read() from int8_t to uint8_t.

### DIFF
--- a/src/esp32/mgos_prometheus_metrics_esp32.c
+++ b/src/esp32/mgos_prometheus_metrics_esp32.c
@@ -11,7 +11,7 @@
 // The typo below is correct, IDF SDK returns temperature in Fahrenheit
 // This is an undocumented feature -- symbol is defined in
 // esp-idf/components/esp32/lib/libphy.a(phy_chip_v7_cal.o)
-extern int8_t temprature_sens_read();
+extern uint8_t temprature_sens_read();
 
 #if MGOS_HAVE_WIFI
 static void metrics_wifi(struct mg_connection *nc) {


### PR DESCRIPTION
If `temprature_sens_read()` is defined as `int8_t`, the `esp32_temperature` metric is negative.
Example:
```
# HELP esp32_temperature ESP32 Internal Temperature in Celcius
# TYPE esp32_temperature gauge
esp32_temperature -72.8
```
Changed to `uint8_t` and the result is positive:
```
# HELP esp32_temperature ESP32 Internal Temperature in Celcius
# TYPE esp32_temperature gauge
esp32_temperature 68.9
```