### PR TITLE
Update to allow lib to build using mos 2.12.1

### DIFF
--- a/src/esp32/mgos_prometheus_metrics_esp32.c
+++ b/src/esp32/mgos_prometheus_metrics_esp32.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <FreeRTOS.h>
 #include <esp_system.h>
 #include <freertos/task.h>
 #include "mgos_prometheus_metrics.h"


### PR DESCRIPTION
Updated mos to 2.12.1 and this lib failed to build. 

Updated to fix the following error

In file included from /scratch/git_repos/ythermcam/software/huzzah-featherwing/deps/prometheus-metrics/src/esp32/mgos_prometheus_metrics_esp32.c:17:0:
/opt/Espressif/esp-idf/components/freertos/include/freertos/task.h:75:3: error: #error "include FreeRTOS.h must appear in source files before include task.h"
  #error "include FreeRTOS.h must appear in source files before include task.h"
   ^
