### PR TITLE
 `mgos_uptime` moved to `mgos_time.h`

### DIFF
--- a/src/mgos_prometheus_metrics.c
+++ b/src/mgos_prometheus_metrics.c
@@ -22,6 +22,7 @@
 #include "cache.h"
 #include "mgos_config.h"
 #include "mgos_ro_vars.h"
+#include "mgos_time.h"
 
 static struct cache *metrics_cache = NULL;
 


### PR DESCRIPTION
https://github.com/cesanta/mongoose-os/commit/88a03736d21c2abfe3c9e8cf64a9ea9f4fcd8dae